### PR TITLE
lock vis version to 4.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "lodash": "^4.12.0",
-    "vis": "^4.16.1"
+    "vis": "=4.16.1"
   },
   "peerDependencies": {
     "react": "^0.14 || ^15.0.0-rc || ^15.0",


### PR DESCRIPTION
Would like to lock down visjs version because they updated to 4.17.0 and this version has started causing us problems.