### PR TITLE
Vis peer dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "babel-preset-react": "^6.5.0"
   },
   "dependencies": {
-    "lodash": "^4.12.0",
-    "vis": "^4.16.1"
+    "lodash": "^4.12.0"
   },
   "peerDependencies": {
     "react": "^0.14 || ^15.0.0-rc || ^15.0",
-    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0"
+    "react-dom": "^0.14 || ^15.0.0-rc || ^15.0",
+    "vis": "^4.16.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-visjs-timeline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "React component for the vis.js timeline module",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
It appears the latest vis versions `4.17.0` and `4.18.0` have been causing grief so updating this package to be a peerDependancy so end users can install the relevant versions which work for them.

This was also raised in PR #7, I think we can close this in favour of this PR.