### PR TITLE
Fix setGroups when no groups passed; add support for setSelection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,9 @@ export default class Timeline extends Component {
 
     if (timelineExists) {
       $el.setItems(timelineItems)
-      $el.setGroups(timelineGroups)
+      if (timelineGroups.length > 0) {
+        $el.setGroups(timelineGroups)
+      }
 
       let updatedOptions
 
@@ -112,7 +114,12 @@ export default class Timeline extends Component {
       $el.setSelection(selection)
 
     } else {
-      $el = this.TimelineElement = new vis.Timeline(container, timelineItems, timelineGroups, options)
+      if (timelineGroups.length > 0) {
+        $el = this.TimelineElement = new vis.Timeline(container, timelineItems, timelineGroups, options)
+      }
+      else {
+        $el = this.TimelineElement = new vis.Timeline(container, timelineItems, options)
+      }
 
       events.forEach(event => {
         $el.on(event, this.props[`${event}Handler`])

--- a/src/index.js
+++ b/src/index.js
@@ -93,11 +93,12 @@ export default class Timeline extends Component {
 
     const timelineItems = new vis.DataSet(items)
     const timelineGroups = new vis.DataSet(groups)
+    const hasGroups = timelineGroups.length 
     const timelineExists = !!$el
 
     if (timelineExists) {
       $el.setItems(timelineItems)
-      if (timelineGroups.length > 0) {
+      if (hasGroups) {
         $el.setGroups(timelineGroups)
       }
 
@@ -114,7 +115,7 @@ export default class Timeline extends Component {
       $el.setSelection(selection)
 
     } else {
-      if (timelineGroups.length > 0) {
+      if (hasGroups) {
         $el = this.TimelineElement = new vis.Timeline(container, timelineItems, timelineGroups, options)
       }
       else {

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ export default class Timeline extends Component {
       items,
       groups,
       options,
+      selection,
       customTimes
     } = this.props
 
@@ -84,6 +85,7 @@ export default class Timeline extends Component {
       items,
       groups,
       options,
+      selection,
       customTimes,
       animate = true,
       currentTime
@@ -107,6 +109,7 @@ export default class Timeline extends Component {
       }
 
       $el.setOptions(updatedOptions)
+      $el.setSelection(selection)
 
     } else {
       $el = this.TimelineElement = new vis.Timeline(container, timelineItems, timelineGroups, options)
@@ -154,6 +157,7 @@ Timeline.propTypes = assign({
   items: PropTypes.array,
   groups: PropTypes.array,
   options: PropTypes.object,
+  selection: PropTypes.array,
   customTimes: PropTypes.shape({
     datetime: PropTypes.instanceOf(Date),
     id: PropTypes.string
@@ -173,5 +177,6 @@ Timeline.defaultProps = assign({
   items: [],
   groups: null,
   options: {},
+  selection: [],
   customTimes: {},
 }, eventDefaultProps)


### PR DESCRIPTION
This PR is two things in one:

1. It seems that introducing support for groups (1.3.0) would break setups when no groups were passed, despite the default value of `null` - no items would then be drawn. This is fixed by setting groups only if any are passed.
2. Added support for setting selected items manually using the `selection` parameter. This is useful if you wish to sync selected items with a state object and dispatch actions when items are (de)selected.