### PR TITLE
Added shim to quiet 15.5 warning about using React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "babel-preset-react": "^6.5.0"
   },
   "dependencies": {
-    "lodash": "^4.12.0"
+    "lodash": "^4.12.0",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "react": "^0.14 || ^15.0.0-rc || ^15.0",
     "react-dom": "^0.14 || ^15.0.0-rc || ^15.0",
-    "vis": "^4.16.1"
+    "vis": "^4.16.1",
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,28 @@
 import vis from 'vis'
 import 'vis/dist/vis.css'
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
 import each from 'lodash/each'
 import assign from 'lodash/assign'
 import omit from 'lodash/omit'
 import keys from 'lodash/keys'
+
+const PropTypeShimRequired = () => {
+  // Is React >= 15.5?
+  if (React.version && typeof React.version === 'string') {
+      const version = React.version.split('.')
+      const major = parseInt(version[0])
+      const minor = parseInt(version[1])
+      return (major > 15 || (major == 15 && minor >= 5))
+  }
+}
+
+const PropTypes = (PropTypeShimRequired())
+? require('prop-types')
+: require('react').PropTypes
+
+
 
 const noop = function() {}
 const events = [


### PR DESCRIPTION
I've been using this library for a while and noticed that after updating my React library to 15.5.4 that a new warning pops up:

> Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

According to the [React 15.5 release notes](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) this is triggered when using React.PropTypes.

I've just added a shim that utilizes the recommended new package (prop-types) when the used React library is >= 15.5. For older React library this should default to the existing React.PropTypes.
