### PR TITLE
Illustrate case-sensitivity of event handler prop names

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,14 @@ When the `customTimes` prop changes, the updated times will be reflected in the 
 
 ## Events
 
-All events are supported via prop function handlers. The prop name follows the convention `<eventName>Handler` and the specified function will receive the same arguments as the [vis.js counterparts](http://visjs.org/docs/timeline/#Events)
+All events are supported via prop function handlers. The prop name follows the convention `<eventName>Handler` and the specified function will receive the same arguments as the [vis.js counterparts](http://visjs.org/docs/timeline/#Events).
+Some visjs event names are not camelcased (e.g. `rangechange`), so the corresponding React prop names need to follow that convention where necessary:
 
 ```
 <Timeline
   options={options}
   clickHandler={clickHandler}
-  rangeChangeHandler={rangeChangeHandler}
+  rangechangeHandler={rangeChangeHandler}
 />
 
 function clickHandler(props) {


### PR DESCRIPTION
# Overview
Per the vis.js Event docs (http://visjs.org/docs/timeline/#Events), not all event names are camelcased. The `fooHandler` prop name syntax of this React component needs to match the casing of vis.js, or the handlers won't fire. Thus, the `rangeChangeHandler` example in the README won't work as-is (should be `rangechangeHandler`). I lost a good few minutes trying to debug this!

## Updates

* Clarified README's event handler section; changed `rangeChangeHandler` to `rangechangeHandler`.

## Dependencies

## Outstanding Tasks

## Screenshots (if appropriate)
