### PR TITLE
More advanced change detection

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@
 .github
 
 examples
-src

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "release": "node_modules/.bin/babel src --ignore *.test.js --out-dir build",
     "prepublish": "npm run release",
+    "prepare": "npm run release",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
# Overview
Currently, when *any* of the props change, the entire timeline is re-initialized. This PR introduces more fine-grained change detection, in which only the parts (options, items, groups, etc.) that have changed are actually updated.
