### PR TITLE
Make container element use all available vertical space to allow for dynamic sizing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ export default class Timeline extends Component {
   }
 
   render() {
-    return <div ref="container" />
+    return <div ref="container" style={{ height: '100%' }} />
   }
 }
 


### PR DESCRIPTION
# Overview
This change allows the use of the timeline component inside a dynamically sized container.
The previous implementation required specification of height in absolute values.

## Updates
Changed a single line of code

## Dependencies
--

## Outstanding Tasks
--

## Screenshots (if appropriate)
--